### PR TITLE
fix: add logs script to all pages

### DIFF
--- a/changelog.d/20250430_201825_muhammad.labeeb_add_logs_logic_on_all_pages.md
+++ b/changelog.d/20250430_201825_muhammad.labeeb_add_logs_logic_on_all_pages.md
@@ -1,0 +1,1 @@
+ - [Bugfix] Add logs script to all pages so each page can handle completion of a command itself and not delegate it to a page with logs script. (by @mlabeeb03) 

--- a/tutordeck/server/templates/advanced.html
+++ b/tutordeck/server/templates/advanced.html
@@ -91,7 +91,5 @@ Search for any tutor command and execute it with a single click.
         }, 200);
     });
 </script>
-
-<script src="{{ url_for('static', filename='js/logs.js') }}"></script>
 {% endblock %}
 

--- a/tutordeck/server/templates/index.html
+++ b/tutordeck/server/templates/index.html
@@ -117,6 +117,7 @@
         }
     </script>
     {% block scripts %}{% endblock %}
+    <script src="{{ url_for('static', filename='js/logs.js') }}"></script>
 </body>
 
 </html>

--- a/tutordeck/server/templates/local_launch.html
+++ b/tutordeck/server/templates/local_launch.html
@@ -36,5 +36,4 @@ This will run Launch Platform to apply all plugin changes. This may take a few m
     }
     ShowRunCommandButton();
 </script>
-<script src="{{ url_for('static', filename='js/logs.js') }}"></script>
 {% endblock %}

--- a/tutordeck/server/templates/plugin.html
+++ b/tutordeck/server/templates/plugin.html
@@ -105,6 +105,4 @@
             });
         });
     </script>
-
-    <script src="{{ url_for('static', filename='js/logs.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
close #14.
This PR will fix the issue mentioned in #14.
We have added the logs script to all pages so that each page can handle the completion of logs itself whenever the command execution if completed. 