### PR TITLE
feat: only allow relevant pages to cancel running command

### DIFF
--- a/changelog.d/20250508_153631_muhammad.labeeb_improve_cancellation_flows.md
+++ b/changelog.d/20250508_153631_muhammad.labeeb_improve_cancellation_flows.md
@@ -1,0 +1,2 @@
+- [Feature] Only allow command cancellation from relevant page. (by @mlabeeb03)
+- [Feature] Add link to developer panel while command is in progress. (by @mlabeeb03)

--- a/tutordeck/server/static/js/deck.js
+++ b/tutordeck/server/static/js/deck.js
@@ -113,3 +113,40 @@ function setToastContent(cmd) {
 		toastFooter.style.display = config.showFooter ? "flex" : "none";
 	}
 }
+
+// Each page defines its own relevant commands, we use them to check
+// if the currently running commands belong the currently opened page or not
+let relevantCommands = [];
+let onDeveloperPage = false;
+function onRelevantPage(command) {
+	if (onDeveloperPage) {
+		// Developer page is relevant to all commands
+		return true;
+	}
+	return relevantCommands.some((prefix) => command.startsWith(prefix));
+}
+
+function activateInputs() {
+	document.querySelectorAll("button").forEach((button) => {
+		button.disabled = false;
+	});
+	document.querySelectorAll("input").forEach((input) => {
+		input.disabled = false;
+	});
+	document.querySelectorAll(".form-switch").forEach((formSwitch) => {
+		formSwitch.style.opacity = 1;
+	});
+	document.getElementById("warning-command-running").style.display = "none";
+}
+function deactivateInputs() {
+	document.querySelectorAll("button").forEach((button) => {
+		button.disabled = true;
+	});
+	document.querySelectorAll("input").forEach((input) => {
+		input.disabled = true;
+	});
+	document.querySelectorAll(".form-switch").forEach((formSwitch) => {
+		formSwitch.style.opacity = 0.5;
+	});
+	document.getElementById("warning-command-running").style.display = "flex";
+}

--- a/tutordeck/server/static/scss/deck.scss
+++ b/tutordeck/server/static/scss/deck.scss
@@ -23,6 +23,11 @@ $green-1: #edfff7;
 	opacity: 1;
 }
 
+button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
 @mixin command {
 	width: 9em;
 	height: 3em;
@@ -351,6 +356,26 @@ main {
 				color: $gray-4;
 				padding: 0.5em 1em;
 				margin-bottom: 2em;
+				span {
+					margin-left: 1em;
+				}
+
+				img {
+					width: 2em;
+				}
+			}
+			#warning-command-running {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				display: none;
+				border: 1px solid $gray-2;
+				border-radius: 0.5em;
+				align-items: center;
+				font-size: 1.25em;
+				color: $gray-4;
+				padding: 0.5em 1em;
+				margin-top: 1em;
 				span {
 					margin-left: 1em;
 				}
@@ -689,6 +714,7 @@ main {
 
 			.tutor-logs-container {
 				#tutor-logs {
+					display: none;
 					width: 100%;
 					background-color: black;
 					color: white;

--- a/tutordeck/server/templates/advanced.html
+++ b/tutordeck/server/templates/advanced.html
@@ -34,6 +34,8 @@ Search for any tutor command and execute it with a single click.
 
 {% block scripts %}
 <script>
+    onDeveloperPage = true;
+    logsElement.style.display = "block";
     runCommandButton = document.querySelector('.run-command-button')
     cancelCommandButton = document.querySelector('.cancel-command-button') 
     const toggleButtons = ({run = false, cancel = false} = {}) => {

--- a/tutordeck/server/templates/index.html
+++ b/tutordeck/server/templates/index.html
@@ -49,7 +49,13 @@
         </nav>
 
         <section>
-            <header>{% block workspace_header %}{% endblock %}</header>
+            <header>
+                <div id="warning-command-running">
+                    <img src="{{ url_for('static', filename='/img/Featured icon.svg')}}" alt="">
+                    <span>Command execution in progress. <a href="{{ url_for('advanced') }}">Click here</a> to view details.</span>
+                </div>
+                {% block workspace_header %}{% endblock %}
+            </header>
             <section>
                 {% block workspace_content %}
                 {% endblock %}
@@ -111,10 +117,6 @@
     {% endif %}
     <script>
         const logsElement = document.getElementById("tutor-logs");
-        show_logs = '{{ show_logs }}' === 'True';
-        if (!show_logs){
-            logsElement.style.display = 'none';
-        }
     </script>
     {% block scripts %}{% endblock %}
     <script src="{{ url_for('static', filename='js/logs.js') }}"></script>

--- a/tutordeck/server/templates/local_launch.html
+++ b/tutordeck/server/templates/local_launch.html
@@ -24,6 +24,7 @@ This will run Launch Platform to apply all plugin changes. This may take a few m
 
 {% block scripts %}
 <script>
+    relevantCommands = ["tutor local launch --non-interactive"];
     localLaunchButton = document.getElementById('local-launch-button')
     cancelLocalLaunchButton = document.getElementById('cancel-local-launch-button') 
     const toggleButtons = ({run = false, cancel = false} = {}) => {

--- a/tutordeck/server/templates/plugin.html
+++ b/tutordeck/server/templates/plugin.html
@@ -53,6 +53,8 @@
     pluginInstallButton = document.getElementById('plugin-install-button');
     cancelCommandButton = document.getElementById('cancel-command-button');
 
+    relevantCommands = ["tutor plugins install", "tutor plugins upgrade"];
+
     const toggleButtons = ({install = false, upgrade = false, cancel = false} = {}) => {
         pluginInstallButton.style.display = install ? 'block' : 'none';
         pluginUpgradeButton.style.display = upgrade ? 'block' : 'none';


### PR DESCRIPTION
This PR improves the cancellation flow while running parallel commands.
Parallel commands can now only be cancelled from the page they were run from or from the developer panel.
While a parallel command is running all other command running button are disabled.
Add a link to the developer panel while a parallel command execution is in progress.